### PR TITLE
Add `down-options` configuration option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: isbang/compose-action@v0.1
         with:
           compose-file: './docker/docker-compose.yml'
-          down-options: '--volumes'
+          down-flags: '--volumes'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,3 +9,4 @@ jobs:
       - uses: isbang/compose-action@v0.1
         with:
           compose-file: './docker/docker-compose.yml'
+          down-options: '--volumes'

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ This action runs your docker-compose file and clean up before action finished.
 
 **Optional** The name of the compose file. Default `"./docker-compose.yml"`.
 
+### `down-options`
+
+**Optional** Options to pass to the `docker-compose down` command during cleanup. Default is none. Primarily used to pass the `--volumes` flag if you want persistent volumes to be deleted as well during cleanup.
+
+
 ## Example usage
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This action runs your docker-compose file and clean up before action finished.
 
 **Optional** The name of the compose file. Default `"./docker-compose.yml"`.
 
-### `down-options`
+### `down-flags`
 
-**Optional** Options to pass to the `docker-compose down` command during cleanup. Default is none. Primarily used to pass the `--volumes` flag if you want persistent volumes to be deleted as well during cleanup.
+**Optional** Used to specify flags to pass to the `docker-compose down` command during cleanup. Default is none. Can be used to pass the `--volumes` flag, for example, if you want persistent volumes to be deleted as well during cleanup. A full list of flags can be found in the [docker-compose down documentation](https://docs.docker.com/compose/reference/down/).
 
 
 ## Example usage

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'relative path to compose file'
     required: false
     default: './docker-compose.yml'
+  down-options:  # id of input
+    description: 'additional options to pass to `docker-compose down` command'
+    required: false
+    default: ''
 runs:
   using: 'node12'
   main: 'main.js'

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: 'relative path to compose file'
     required: false
     default: './docker-compose.yml'
-  down-options:  # id of input
+  down-flags:  # id of input
     description: 'additional options to pass to `docker-compose down` command'
     required: false
     default: ''

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,10 @@
 version: "3.8"
+
+volumes:
+  test_volume: {}
+
 services:
   helloworld:
     image: hello-world
+    volumes:
+      - test_volume:/test:Z

--- a/post.js
+++ b/post.js
@@ -6,10 +6,9 @@ try {
   const composeFile = core.getInput('compose-file');
   const downOptionsString = core.getInput('down-options');
 
+  let options = { config: composeFile, log: true};
   if (downOptionsString.length > 0)
-    let options = { config: composeFile, log: true, commandOptions: downOptionsString.split(" ") };
-  else
-    let options = { config: composeFile, log: true};
+    options['commandOptions'] = downOptionsString.split(" ");
 
   if (!fs.existsSync(composeFile)) {
     console.log(`${composeFile} not exists`);

--- a/post.js
+++ b/post.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 
 try {
   const composeFile = core.getInput('compose-file');
-  const downOptions = core.getInput('down-options');
+  const downOptions = core.getInput('down-options').split(" ");
 
   if (!fs.existsSync(composeFile)) {
     console.log(`${composeFile} not exists`);

--- a/post.js
+++ b/post.js
@@ -4,13 +4,14 @@ const fs = require('fs');
 
 try {
   const composeFile = core.getInput('compose-file');
+  const downOptions = core.getInput('down-options');
 
   if (!fs.existsSync(composeFile)) {
     console.log(`${composeFile} not exists`);
     return
   }
 
-  compose.down({ config: composeFile, log: true })
+  compose.down({ config: composeFile, log: true, commandOptions: downOptions })
     .then(
       () => { console.log('compose removed')},
       err => { core.setFailed(`compose down failed ${err}`)}

--- a/post.js
+++ b/post.js
@@ -4,11 +4,11 @@ const fs = require('fs');
 
 try {
   const composeFile = core.getInput('compose-file');
-  const downOptionsString = core.getInput('down-options');
+  const downFlagsString = core.getInput('down-flags');
 
   let options = { config: composeFile, log: true};
-  if (downOptionsString.length > 0)
-    options['commandOptions'] = downOptionsString.split(" ");
+  if (downFlagsString.length > 0)
+    options['commandOptions'] = downFlagsString.split(" ");
 
   if (!fs.existsSync(composeFile)) {
     console.log(`${composeFile} not exists`);

--- a/post.js
+++ b/post.js
@@ -4,14 +4,19 @@ const fs = require('fs');
 
 try {
   const composeFile = core.getInput('compose-file');
-  const downOptions = core.getInput('down-options').split(" ");
+  const downOptionsString = core.getInput('down-options');
+
+  if (downOptionsString.length > 0)
+    let options = { config: composeFile, log: true, commandOptions: downOptionsString.split(" ") };
+  else
+    let options = { config: composeFile, log: true};
 
   if (!fs.existsSync(composeFile)) {
     console.log(`${composeFile} not exists`);
     return
   }
 
-  compose.down({ config: composeFile, log: true, commandOptions: downOptions })
+  compose.down(options)
     .then(
       () => { console.log('compose removed')},
       err => { core.setFailed(`compose down failed ${err}`)}


### PR DESCRIPTION
This new, optional configuration parameter allows for the specification of flags to be passed to the `docker-compose down` command. This is primarily intended to be used for passing the `--volumes` flag which instructs docker-compose to also delete persistent volumes.