### PR TITLE
Fix version in example action

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This action runs your docker-compose file and clean up before action finished.
 steps:
   # need checkout before using compose-action
   - uses: actions/checkout@v2
-  - uses: isbang/compose-action@v1
+  - uses: isbang/compose-action@v1.0.0
     with:
       compose-file: './docker/docker-compose.yml'
       down-flags: '--volumes'


### PR DESCRIPTION
Unfortunately, GitHub actions isn't quite smart enough to reduce the version number from `v1.0.0` to `v1`. The full `v1.0.0` must be specified in order for the action to properly run. 